### PR TITLE
Sprint 10: User and Film controllers + validation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@ target/
 *.iws
 *.iml
 *.ipr
+/.idea/
 
 ### NetBeans ###
 /nbproject/private/

--- a/pom.xml
+++ b/pom.xml
@@ -20,6 +20,9 @@
 
 	<properties>
 		<java.version>21</java.version>
+		<maven.compiler.source>21</maven.compiler.source>
+		<maven.compiler.target>21</maven.compiler.target>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 	</properties>
 
 
@@ -42,6 +45,11 @@
 			<scope>test</scope>
 		</dependency>
 
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-validation</artifactId>
+		</dependency>
+
 	</dependencies>
 
 
@@ -51,6 +59,19 @@
 			<plugin>
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>
+			</plugin>
+
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<configuration>
+					<annotationProcessorPaths>
+						<path>
+							<groupId>org.projectlombok</groupId>
+							<artifactId>lombok</artifactId>
+						</path>
+					</annotationProcessorPaths>
+				</configuration>
 			</plugin>
 
 		</plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -2,21 +2,29 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
+
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.2.4</version>
+		<version>3.4.3</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
+
+
 	<groupId>ru.yandex.practicum</groupId>
 	<artifactId>filmorate</artifactId>
 	<version>0.0.1-SNAPSHOT</version>
 	<name>filmorate</name>
 	<description>filmorate</description>
+
+
 	<properties>
 		<java.version>21</java.version>
 	</properties>
+
+
 	<dependencies>
+
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-web</artifactId>
@@ -27,20 +35,26 @@
 			<artifactId>lombok</artifactId>
 			<scope>provided</scope>
 		</dependency>
+
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
 		</dependency>
+
 	</dependencies>
+
 
 	<build>
 		<plugins>
+
 			<plugin>
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>
 			</plugin>
+
 		</plugins>
 	</build>
+
 
 </project>

--- a/src/main/java/ru/yandex/practicum/filmorate/controller/FilmController.java
+++ b/src/main/java/ru/yandex/practicum/filmorate/controller/FilmController.java
@@ -1,7 +1,67 @@
 package ru.yandex.practicum.filmorate.controller;
 
-import org.springframework.web.bind.annotation.RestController;
+import jakarta.validation.Valid;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.*;
+import ru.yandex.practicum.filmorate.model.Film;
+import ru.yandex.practicum.filmorate.model.exceptions.NotFoundException;
+import ru.yandex.practicum.filmorate.model.exceptions.ValidationException;
+import ru.yandex.practicum.filmorate.model.validators.film.*;
 
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+
+@Slf4j
 @RestController
+@RequestMapping("/films")
 public class FilmController {
+
+    FilmValidator filmValidator = FilmValidatorBuilder.builder()
+            .register(new FilmNameValidator())
+            .register(new FilmDescriptionValidator())
+            .register(new FilmReleaseDateValidator())
+            .register(new FilmDurationValidator())
+            .build();
+
+    Map<Long, Film> films = new HashMap<>();
+
+    @GetMapping
+    public Collection<Film> getFilms() {
+        return films.values();
+    }
+
+    @GetMapping("/{id}")
+    public Film getFilmById(@PathVariable Long id) throws NotFoundException {
+        Film film = films.get(id);
+        if (film == null) throw new NotFoundException("Film not found", id);
+        return film;
+    }
+
+    @PostMapping
+    public Film createFilm(@Valid @RequestBody Film film) throws ValidationException {
+        filmValidator.validate(film);
+        film.setId(getNextId());
+        films.put(film.getId(), film);
+        log.info("Added film {}", film);
+        return film;
+    }
+
+    @PutMapping
+    public Film updateFilm(@Valid @RequestBody Film film) throws NotFoundException, ValidationException {
+        filmValidator.validate(film);
+        Film oldFilm = films.get(film.getId());
+        if (oldFilm == null) throw new NotFoundException("Film not found", film);
+        oldFilm.setName(film.getName());
+        oldFilm.setDescription(film.getDescription());
+        oldFilm.setReleaseDate(film.getReleaseDate());
+        oldFilm.setDuration(film.getDuration());
+        log.info("Updated film {}", oldFilm);
+        return oldFilm;
+    }
+
+    private Long getNextId() {
+        return films.keySet().stream().mapToLong(id -> id).max().orElse(0) + 1;
+    }
+
 }

--- a/src/main/java/ru/yandex/practicum/filmorate/controller/GlobalExceptionHandler.java
+++ b/src/main/java/ru/yandex/practicum/filmorate/controller/GlobalExceptionHandler.java
@@ -1,0 +1,37 @@
+package ru.yandex.practicum.filmorate.controller;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import ru.yandex.practicum.filmorate.model.exceptions.NotFoundException;
+import ru.yandex.practicum.filmorate.model.exceptions.ValidationException;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(ValidationException.class)
+    public ResponseEntity<String> handleValidationException(ValidationException e) {
+        log.warn("CUSTOM VALIDATION FAILED: {} for {}", e.getMessage(), e.getObject());
+        return new ResponseEntity<>(e.getMessage(), HttpStatus.BAD_REQUEST);
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<String> handleMethodArgumentNotValidException(MethodArgumentNotValidException e) {
+        String errorMessage = e.getBindingResult().getAllErrors().getFirst().getDefaultMessage();
+        Object target = e.getBindingResult().getTarget();
+        log.warn("SPRING VALIDATION FAILED: {} for {}", errorMessage, target);
+        return new ResponseEntity<>(errorMessage, HttpStatus.BAD_REQUEST);
+    }
+
+    @ExceptionHandler(NotFoundException.class)
+    public ResponseEntity<String> handleNotFoundException(NotFoundException e) {
+        log.warn("SEARCH FAILED: {} for {}", e.getMessage(), e.getObject());
+        return new ResponseEntity<>(e.getMessage(), HttpStatus.NOT_FOUND);
+    }
+
+
+}

--- a/src/main/java/ru/yandex/practicum/filmorate/controller/UserController.java
+++ b/src/main/java/ru/yandex/practicum/filmorate/controller/UserController.java
@@ -1,0 +1,67 @@
+package ru.yandex.practicum.filmorate.controller;
+
+import jakarta.validation.Valid;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.*;
+import ru.yandex.practicum.filmorate.model.User;
+import ru.yandex.practicum.filmorate.model.exceptions.NotFoundException;
+import ru.yandex.practicum.filmorate.model.exceptions.ValidationException;
+import ru.yandex.practicum.filmorate.model.validators.user.*;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+
+@Slf4j
+@RestController
+@RequestMapping("/users")
+public class UserController {
+
+    UserValidator userValidator = UserValidatorBuilder.builder()
+            .register(new UserEmailValidator())
+            .register(new UserLoginValidator())
+            .register(new UserNameValidator())
+            .register(new UserBirthdayValidator())
+            .build();
+
+    Map<Long, User> users = new HashMap<>();
+
+    @GetMapping
+    public Collection<User> getUsers() {
+        return users.values();
+    }
+
+    @GetMapping("/{id}")
+    public User getUserById(@PathVariable Long id) throws NotFoundException {
+        User user = users.get(id);
+        if (user == null) throw new NotFoundException("User not found", id);
+        return user;
+    }
+
+    @PostMapping
+    public User createUser(@Valid @RequestBody User user) throws ValidationException {
+        userValidator.validate(user);
+        user.setId(getNextId());
+        users.put(user.getId(), user);
+        log.info("Added user {}", user);
+        return user;
+    }
+
+    @PutMapping
+    public User updateUser(@Valid @RequestBody User user) throws ValidationException, NotFoundException {
+        userValidator.validate(user);
+        User oldUser = users.get(user.getId());
+        if (oldUser == null) throw new NotFoundException("User not found", user);
+        oldUser.setEmail(user.getEmail());
+        oldUser.setLogin(user.getLogin());
+        oldUser.setName(user.getName());
+        oldUser.setBirthday(user.getBirthday());
+        log.info("Updated user {}", oldUser);
+        return oldUser;
+    }
+
+    private Long getNextId() {
+        return users.keySet().stream().mapToLong(id -> id).max().orElse(0) + 1;
+    }
+
+}

--- a/src/main/java/ru/yandex/practicum/filmorate/model/Film.java
+++ b/src/main/java/ru/yandex/practicum/filmorate/model/Film.java
@@ -1,12 +1,26 @@
 package ru.yandex.practicum.filmorate.model;
 
-import lombok.Getter;
-import lombok.Setter;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Data;
+
+import java.time.Duration;
+import java.time.LocalDate;
 
 /**
  * Film.
  */
-@Getter
-@Setter
+@Data
 public class Film {
+
+    long id;
+
+    @NotBlank(message = "@Valid: Film name shouldn't be blank")
+    String name;
+
+    String description;
+
+    LocalDate releaseDate;
+
+    Duration duration;
+
 }

--- a/src/main/java/ru/yandex/practicum/filmorate/model/User.java
+++ b/src/main/java/ru/yandex/practicum/filmorate/model/User.java
@@ -1,0 +1,24 @@
+package ru.yandex.practicum.filmorate.model;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Data;
+
+import java.time.LocalDate;
+
+@Data
+public class User {
+
+    long id;
+
+    @Email(message = "@Valid: User Email doesn't match email mask")
+    String email;
+
+    @NotBlank(message = "@Valid: User login shouldn't be blank")
+    String login;
+
+    String name;
+
+    LocalDate birthday;
+
+}

--- a/src/main/java/ru/yandex/practicum/filmorate/model/exceptions/NotFoundException.java
+++ b/src/main/java/ru/yandex/practicum/filmorate/model/exceptions/NotFoundException.java
@@ -1,0 +1,15 @@
+package ru.yandex.practicum.filmorate.model.exceptions;
+
+import lombok.Getter;
+
+public class NotFoundException extends Exception {
+
+    @Getter
+    Object object;
+
+    public NotFoundException(String message, Object object) {
+        super(message);
+        this.object = object;
+    }
+
+}

--- a/src/main/java/ru/yandex/practicum/filmorate/model/exceptions/ValidationException.java
+++ b/src/main/java/ru/yandex/practicum/filmorate/model/exceptions/ValidationException.java
@@ -1,0 +1,15 @@
+package ru.yandex.practicum.filmorate.model.exceptions;
+
+import lombok.Getter;
+
+public class ValidationException extends Exception {
+
+    @Getter
+    Object object;
+
+    public ValidationException(String message, Object object) {
+        super(message);
+        this.object = object;
+    }
+
+}

--- a/src/main/java/ru/yandex/practicum/filmorate/model/validators/film/FilmAbstractValidator.java
+++ b/src/main/java/ru/yandex/practicum/filmorate/model/validators/film/FilmAbstractValidator.java
@@ -1,0 +1,23 @@
+package ru.yandex.practicum.filmorate.model.validators.film;
+
+import ru.yandex.practicum.filmorate.model.Film;
+import ru.yandex.practicum.filmorate.model.exceptions.ValidationException;
+
+public abstract class FilmAbstractValidator implements FilmValidator {
+
+    private FilmValidator next;
+
+    @Override
+    public void setNext(FilmValidator next) {
+        this.next = next;
+    }
+
+    @Override
+    public void validate(Film film) throws ValidationException {
+        performValidation(film);
+        if (next != null) next.validate(film);
+    }
+
+    protected abstract void performValidation(Film film) throws ValidationException;
+
+}

--- a/src/main/java/ru/yandex/practicum/filmorate/model/validators/film/FilmDescriptionValidator.java
+++ b/src/main/java/ru/yandex/practicum/filmorate/model/validators/film/FilmDescriptionValidator.java
@@ -1,0 +1,27 @@
+package ru.yandex.practicum.filmorate.model.validators.film;
+
+import lombok.extern.slf4j.Slf4j;
+import ru.yandex.practicum.filmorate.model.Film;
+import ru.yandex.practicum.filmorate.model.exceptions.ValidationException;
+
+@Slf4j
+public class FilmDescriptionValidator extends FilmAbstractValidator implements FilmValidator {
+
+    private final int MAX_DESCRIPTION_LENGTH = 200;
+
+    @Override
+    protected void performValidation(Film film) throws ValidationException {
+
+        String description = film.getDescription();
+
+        if (description != null && description.length() > MAX_DESCRIPTION_LENGTH) {
+            String reason = "Film description length should be less than " + MAX_DESCRIPTION_LENGTH + " symbols";
+            log.debug("FAILED: {} for {}", reason, film);
+            throw new ValidationException(getClass().getSimpleName() + ": " + reason, film);
+        }
+
+        log.debug("PASSED");
+
+    }
+
+}

--- a/src/main/java/ru/yandex/practicum/filmorate/model/validators/film/FilmDescriptionValidator.java
+++ b/src/main/java/ru/yandex/practicum/filmorate/model/validators/film/FilmDescriptionValidator.java
@@ -7,7 +7,7 @@ import ru.yandex.practicum.filmorate.model.exceptions.ValidationException;
 @Slf4j
 public class FilmDescriptionValidator extends FilmAbstractValidator implements FilmValidator {
 
-    private final int MAX_DESCRIPTION_LENGTH = 200;
+    public static final int MAX_DESCRIPTION_LENGTH = 200;
 
     @Override
     protected void performValidation(Film film) throws ValidationException {

--- a/src/main/java/ru/yandex/practicum/filmorate/model/validators/film/FilmDurationValidator.java
+++ b/src/main/java/ru/yandex/practicum/filmorate/model/validators/film/FilmDurationValidator.java
@@ -1,0 +1,27 @@
+package ru.yandex.practicum.filmorate.model.validators.film;
+
+import lombok.extern.slf4j.Slf4j;
+import ru.yandex.practicum.filmorate.model.Film;
+import ru.yandex.practicum.filmorate.model.exceptions.ValidationException;
+
+import java.time.Duration;
+
+@Slf4j
+public class FilmDurationValidator extends FilmAbstractValidator implements FilmValidator {
+
+    @Override
+    protected void performValidation(Film film) throws ValidationException {
+
+        Duration duration = film.getDuration();
+
+        if (duration != null && !duration.isPositive()) {
+            String reason = "Duration should be positive";
+            log.debug("FAILED: {} for {}", reason, film);
+            throw new ValidationException(getClass().getSimpleName() + ": " + reason, film);
+        }
+
+        log.debug("PASSED");
+
+    }
+
+}

--- a/src/main/java/ru/yandex/practicum/filmorate/model/validators/film/FilmNameValidator.java
+++ b/src/main/java/ru/yandex/practicum/filmorate/model/validators/film/FilmNameValidator.java
@@ -1,0 +1,24 @@
+package ru.yandex.practicum.filmorate.model.validators.film;
+
+import lombok.extern.slf4j.Slf4j;
+import ru.yandex.practicum.filmorate.model.Film;
+import ru.yandex.practicum.filmorate.model.exceptions.ValidationException;
+
+@Slf4j
+public class FilmNameValidator extends FilmAbstractValidator implements FilmValidator {
+
+    @Override
+    protected void performValidation(Film film) throws ValidationException {
+        String name = film.getName();
+
+        if (name == null || name.isBlank()) {
+            String reason = "Film name should be specified";
+            log.debug("FAILED: {} for {}", reason, film);
+            throw new ValidationException(getClass().getSimpleName() + ": " + reason, film);
+        }
+
+        log.debug("PASSED");
+
+    }
+
+}

--- a/src/main/java/ru/yandex/practicum/filmorate/model/validators/film/FilmReleaseDateValidator.java
+++ b/src/main/java/ru/yandex/practicum/filmorate/model/validators/film/FilmReleaseDateValidator.java
@@ -9,7 +9,7 @@ import java.time.LocalDate;
 @Slf4j
 public class FilmReleaseDateValidator extends FilmAbstractValidator implements FilmValidator {
 
-    private final LocalDate MIN_RELEASE_DATE = LocalDate.of(1895, 12, 28);
+    public static final LocalDate MIN_RELEASE_DATE = LocalDate.of(1895, 12, 28);
 
     @Override
     protected void performValidation(Film film) throws ValidationException {

--- a/src/main/java/ru/yandex/practicum/filmorate/model/validators/film/FilmReleaseDateValidator.java
+++ b/src/main/java/ru/yandex/practicum/filmorate/model/validators/film/FilmReleaseDateValidator.java
@@ -1,0 +1,29 @@
+package ru.yandex.practicum.filmorate.model.validators.film;
+
+import lombok.extern.slf4j.Slf4j;
+import ru.yandex.practicum.filmorate.model.Film;
+import ru.yandex.practicum.filmorate.model.exceptions.ValidationException;
+
+import java.time.LocalDate;
+
+@Slf4j
+public class FilmReleaseDateValidator extends FilmAbstractValidator implements FilmValidator {
+
+    private final LocalDate MIN_RELEASE_DATE = LocalDate.of(1895, 12, 28);
+
+    @Override
+    protected void performValidation(Film film) throws ValidationException {
+
+        LocalDate date = film.getReleaseDate();
+
+        if (date != null && date.isBefore(MIN_RELEASE_DATE)) {
+            String reason = "Film release date shouldn't be earlier than " + MIN_RELEASE_DATE;
+            log.debug("FAILED: {} for {}", reason, film);
+            throw new ValidationException(getClass().getSimpleName() + ": " + reason, film);
+        }
+
+        log.debug("PASSED");
+
+    }
+
+}

--- a/src/main/java/ru/yandex/practicum/filmorate/model/validators/film/FilmValidator.java
+++ b/src/main/java/ru/yandex/practicum/filmorate/model/validators/film/FilmValidator.java
@@ -1,0 +1,12 @@
+package ru.yandex.practicum.filmorate.model.validators.film;
+
+import ru.yandex.practicum.filmorate.model.Film;
+import ru.yandex.practicum.filmorate.model.exceptions.ValidationException;
+
+public interface FilmValidator {
+
+    void validate(Film film) throws ValidationException;
+
+    void setNext(FilmValidator next);
+
+}

--- a/src/main/java/ru/yandex/practicum/filmorate/model/validators/film/FilmValidatorBuilder.java
+++ b/src/main/java/ru/yandex/practicum/filmorate/model/validators/film/FilmValidatorBuilder.java
@@ -1,0 +1,27 @@
+package ru.yandex.practicum.filmorate.model.validators.film;
+
+public class FilmValidatorBuilder {
+
+    private FilmValidator head;
+    private FilmValidator tail;
+
+    public static FilmValidatorBuilder builder() {
+        return new FilmValidatorBuilder();
+    }
+
+    public FilmValidatorBuilder register(FilmValidator validator) {
+        if (tail == null) {
+            head = validator;
+        } else {
+            tail.setNext(validator);
+        }
+        tail = validator;
+        return this;
+    }
+
+    public FilmValidator build() {
+        if (head == null) throw new IllegalStateException("At least one validator must be added");
+        return head;
+    }
+
+}

--- a/src/main/java/ru/yandex/practicum/filmorate/model/validators/user/UserAbstractValidator.java
+++ b/src/main/java/ru/yandex/practicum/filmorate/model/validators/user/UserAbstractValidator.java
@@ -1,0 +1,23 @@
+package ru.yandex.practicum.filmorate.model.validators.user;
+
+import ru.yandex.practicum.filmorate.model.User;
+import ru.yandex.practicum.filmorate.model.exceptions.ValidationException;
+
+public abstract class UserAbstractValidator implements UserValidator {
+
+    private UserValidator next;
+
+    @Override
+    public void setNext(UserValidator next) {
+        this.next = next;
+    }
+
+    @Override
+    public void validate(User user) throws ValidationException {
+        performValidation(user);
+        if (next != null) next.validate(user);
+    }
+
+    protected abstract void performValidation(User user) throws ValidationException;
+
+}

--- a/src/main/java/ru/yandex/practicum/filmorate/model/validators/user/UserBirthdayValidator.java
+++ b/src/main/java/ru/yandex/practicum/filmorate/model/validators/user/UserBirthdayValidator.java
@@ -1,0 +1,25 @@
+package ru.yandex.practicum.filmorate.model.validators.user;
+
+import lombok.extern.slf4j.Slf4j;
+import ru.yandex.practicum.filmorate.model.User;
+import ru.yandex.practicum.filmorate.model.exceptions.ValidationException;
+
+import java.time.LocalDate;
+
+@Slf4j
+public class UserBirthdayValidator extends UserAbstractValidator implements UserValidator {
+
+    @Override
+    protected void performValidation(User user) throws ValidationException {
+
+        if (user.getBirthday() != null && user.getBirthday().isAfter(LocalDate.now())) {
+            String reason = "User birthday shouldn't be in future";
+            log.debug("FAILED: {} for {}", reason, user);
+            throw new ValidationException(getClass().getSimpleName() + ": " + reason, user);
+        }
+
+        log.debug("PASSED");
+
+    }
+
+}

--- a/src/main/java/ru/yandex/practicum/filmorate/model/validators/user/UserEmailValidator.java
+++ b/src/main/java/ru/yandex/practicum/filmorate/model/validators/user/UserEmailValidator.java
@@ -9,12 +9,12 @@ import java.util.regex.Pattern;
 @Slf4j
 public class UserEmailValidator extends UserAbstractValidator implements UserValidator {
 
-    private final Pattern EMAIL_PATTERN = Pattern.compile("^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,}$");
+    public static final Pattern EMAIL_PATTERN = Pattern.compile("^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,}$");
 
     @Override
     protected void performValidation(User user) throws ValidationException {
 
-        if ( user.getEmail() == null || !EMAIL_PATTERN.matcher(user.getEmail()).matches() ) {
+        if (user.getEmail() == null || !EMAIL_PATTERN.matcher(user.getEmail()).matches()) {
             String reason = "User email doesn't match email mask";
             log.debug("FAILED: {} for {}", reason, user);
             throw new ValidationException(getClass().getSimpleName() + ": " + reason, user);

--- a/src/main/java/ru/yandex/practicum/filmorate/model/validators/user/UserEmailValidator.java
+++ b/src/main/java/ru/yandex/practicum/filmorate/model/validators/user/UserEmailValidator.java
@@ -1,0 +1,27 @@
+package ru.yandex.practicum.filmorate.model.validators.user;
+
+import lombok.extern.slf4j.Slf4j;
+import ru.yandex.practicum.filmorate.model.User;
+import ru.yandex.practicum.filmorate.model.exceptions.ValidationException;
+
+import java.util.regex.Pattern;
+
+@Slf4j
+public class UserEmailValidator extends UserAbstractValidator implements UserValidator {
+
+    private final Pattern EMAIL_PATTERN = Pattern.compile("^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,}$");
+
+    @Override
+    protected void performValidation(User user) throws ValidationException {
+
+        if ( user.getEmail() == null || !EMAIL_PATTERN.matcher(user.getEmail()).matches() ) {
+            String reason = "User email doesn't match email mask";
+            log.debug("FAILED: {} for {}", reason, user);
+            throw new ValidationException(getClass().getSimpleName() + ": " + reason, user);
+        }
+
+        log.debug("PASSED");
+
+    }
+
+}

--- a/src/main/java/ru/yandex/practicum/filmorate/model/validators/user/UserLoginValidator.java
+++ b/src/main/java/ru/yandex/practicum/filmorate/model/validators/user/UserLoginValidator.java
@@ -11,13 +11,13 @@ public class UserLoginValidator extends UserAbstractValidator implements UserVal
     protected void performValidation(User user) throws ValidationException {
         String login = user.getLogin();
 
-        if ( login == null || login.isBlank() ) {
+        if (login == null || login.isBlank()) {
             String reason = "User login shouldn't be empty";
             log.debug("FAILED: {} for {}", reason, user);
             throw new ValidationException(getClass().getSimpleName() + ": " + reason, user);
         }
 
-        if ( login.indexOf(' ') >= 0 || login.indexOf('\t') >= 0 ) {
+        if (login.indexOf(' ') >= 0 || login.indexOf('\t') >= 0) {
             String reason = "User login shouldn't contain spaces or tabs";
             log.debug("FAILED: {} for {}", reason, user);
             throw new ValidationException(getClass().getSimpleName() + ": " + reason, user);

--- a/src/main/java/ru/yandex/practicum/filmorate/model/validators/user/UserLoginValidator.java
+++ b/src/main/java/ru/yandex/practicum/filmorate/model/validators/user/UserLoginValidator.java
@@ -1,0 +1,30 @@
+package ru.yandex.practicum.filmorate.model.validators.user;
+
+import lombok.extern.slf4j.Slf4j;
+import ru.yandex.practicum.filmorate.model.User;
+import ru.yandex.practicum.filmorate.model.exceptions.ValidationException;
+
+@Slf4j
+public class UserLoginValidator extends UserAbstractValidator implements UserValidator {
+
+    @Override
+    protected void performValidation(User user) throws ValidationException {
+        String login = user.getLogin();
+
+        if ( login == null || login.isBlank() ) {
+            String reason = "User login shouldn't be empty";
+            log.debug("FAILED: {} for {}", reason, user);
+            throw new ValidationException(getClass().getSimpleName() + ": " + reason, user);
+        }
+
+        if ( login.indexOf(' ') >= 0 || login.indexOf('\t') >= 0 ) {
+            String reason = "User login shouldn't contain spaces or tabs";
+            log.debug("FAILED: {} for {}", reason, user);
+            throw new ValidationException(getClass().getSimpleName() + ": " + reason, user);
+        }
+
+        log.debug("PASSED");
+
+    }
+
+}

--- a/src/main/java/ru/yandex/practicum/filmorate/model/validators/user/UserNameValidator.java
+++ b/src/main/java/ru/yandex/practicum/filmorate/model/validators/user/UserNameValidator.java
@@ -1,0 +1,23 @@
+package ru.yandex.practicum.filmorate.model.validators.user;
+
+import lombok.extern.slf4j.Slf4j;
+import ru.yandex.practicum.filmorate.model.User;
+import ru.yandex.practicum.filmorate.model.exceptions.ValidationException;
+
+@Slf4j
+public class UserNameValidator extends UserAbstractValidator implements UserValidator {
+
+    @Override
+    protected void performValidation(User user) throws ValidationException {
+
+        if (user.getName() == null || user.getName().isBlank()) {
+            String reason = "User name is blank. Login will be used instead";
+            log.debug("PASSED: {} for {}", reason, user);
+            user.setName(user.getLogin());
+        } else {
+            log.debug("PASSED");
+        }
+
+    }
+
+}

--- a/src/main/java/ru/yandex/practicum/filmorate/model/validators/user/UserValidator.java
+++ b/src/main/java/ru/yandex/practicum/filmorate/model/validators/user/UserValidator.java
@@ -1,0 +1,12 @@
+package ru.yandex.practicum.filmorate.model.validators.user;
+
+import ru.yandex.practicum.filmorate.model.User;
+import ru.yandex.practicum.filmorate.model.exceptions.ValidationException;
+
+public interface UserValidator {
+
+    void validate(User user) throws ValidationException;
+
+    void setNext(UserValidator next);
+
+}

--- a/src/main/java/ru/yandex/practicum/filmorate/model/validators/user/UserValidatorBuilder.java
+++ b/src/main/java/ru/yandex/practicum/filmorate/model/validators/user/UserValidatorBuilder.java
@@ -1,0 +1,27 @@
+package ru.yandex.practicum.filmorate.model.validators.user;
+
+public class UserValidatorBuilder {
+
+    private UserValidator head;
+    private UserValidator tail;
+
+    public static UserValidatorBuilder builder() {
+        return new UserValidatorBuilder();
+    }
+
+    public UserValidatorBuilder register(UserValidator validator) {
+        if (tail == null) {
+            head = validator;
+        } else {
+            tail.setNext(validator);
+        }
+        tail = validator;
+        return this;
+    }
+
+    public UserValidator build() {
+        if (head == null) throw new IllegalStateException("At least one validator must be added");
+        return head;
+    }
+
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,1 @@
-
+logging.level.root=INFO

--- a/src/test/java/ru/yandex/practicum/filmorate/FilmorateApplicationTests.java
+++ b/src/test/java/ru/yandex/practicum/filmorate/FilmorateApplicationTests.java
@@ -1,13 +1,289 @@
 package ru.yandex.practicum.filmorate;
 
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.http.*;
 
-@SpringBootTest
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 class FilmorateApplicationTests {
 
-	@Test
-	void contextLoads() {
-	}
+    @Autowired
+    private TestRestTemplate restTemplate;
+
+
+    /**
+     * Endpoint: /users
+     */
+    @Test
+    void usersEndpoint() {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        HttpEntity<String> request;
+        ResponseEntity<String> response;
+        String body;
+
+        // ###### POST ######
+
+        Map<String, String[]> postJsons = new HashMap<>();
+        // Bad jsons
+        postJsons.put("", new String[]{"400", "Bad Request"});
+        postJsons.put("hrtfhyrth", new String[]{"400", "Bad Request"});
+        postJsons.put("{}", new String[]{"400", "@Valid"});
+        postJsons.put("{\"king\":\"sauron\"}", new String[]{"400", "@Valid"});
+        // Empty email + bad email
+        postJsons.put("{\"email\":\"ivanya.ru\",\"login\":\"ivandur\",\"name\":\"ivan durak\",\"birthday\":\"2000-02-24\"}",
+                new String[]{"400", "@Valid"});
+        postJsons.put("{\"email\":\"\",\"login\":\"ivandur\",\"name\":\"ivan durak\",\"birthday\":\"2000-02-24\"}",
+                new String[]{"400", "UserEmailValidator"});
+        // Empty login + login with spaces
+        postJsons.put("{\"email\":\"ivan@ya.ru\",\"login\":\"\",\"name\":\"ivan durak\",\"birthday\":\"2000-02-24\"}",
+                new String[]{"400", "@Valid"});
+        postJsons.put("{\"email\":\"ivan@ya.ru\",\"login\":\"iva ndur\",\"name\":\"ivan durak\",\"birthday\":\"2000-02-24\"}",
+                new String[]{"400", "UserLoginValidator"});
+        // Birthday from future
+        postJsons.put("{\"email\":\"ivan@ya.ru\",\"login\":\"ivandur\",\"name\":\"ivan durak\",\"birthday\":\"2040-02-24\"}",
+                new String[]{"400", "UserBirthdayValidator"});
+        // Empty name + without name
+        postJsons.put("{\"email\":\"ivan@ya.ru\",\"login\":\"ivandur\",\"name\":\"\",\"birthday\":\"2000-02-24\"}",
+                new String[]{"200", "ivandur"});
+        postJsons.put("{\"email\":\"sofi@ya.ru\",\"login\":\"sofochka\",\"birthday\":\"2001-04-14\"}",
+                new String[]{"200", "sofochka"});
+        // Normal json (with id + without id)
+        postJsons.put("{\"email\":\"oleg@ya.ru\",\"login\":\"olezhe\",\"name\":\"olen oleg\",\"birthday\":\"2003-06-21\"}",
+                new String[]{"200", "olezhe"});
+        postJsons.put("{\"id\":1,\"email\":\"otto@ya.ru\",\"login\":\"bismark\",\"name\":\"otto bismark\",\"birthday\":\"1815-04-01\"}",
+                new String[]{"200", "bismark"});
+
+        for (Map.Entry<String, String[]> entry : postJsons.entrySet()) {
+            request = new HttpEntity<>(entry.getKey(), headers);
+            response = restTemplate.exchange("/users", HttpMethod.POST, request, String.class);
+            assertEquals(entry.getValue()[0], String.valueOf(response.getStatusCode().value()));
+            body = response.getBody();
+            assertNotNull(body);
+            assertTrue(body.contains(entry.getValue()[1]));
+        }
+
+        // ###### PUT ######
+
+        Map<String, String[]> putJsons = new HashMap<>();
+        // Bad jsons
+        putJsons.put("", new String[]{"400", "Bad Request"});
+        putJsons.put("hrtfhyrth", new String[]{"400", "Bad Request"});
+        putJsons.put("{}", new String[]{"400", "@Valid"});
+        putJsons.put("{\"king\":\"sauron\"}", new String[]{"400", "@Valid"});
+        // Empty email + bad email
+        putJsons.put("{\"email\":\"ivanya.ru\",\"login\":\"ivandur\",\"name\":\"ivan durak\",\"birthday\":\"2000-02-24\"}",
+                new String[]{"400", "@Valid"});
+        putJsons.put("{\"email\":\"\",\"login\":\"ivandur\",\"name\":\"ivan durak\",\"birthday\":\"2000-02-24\"}",
+                new String[]{"400", "UserEmailValidator"});
+        // Empty login + login with spaces
+        putJsons.put("{\"email\":\"ivan@ya.ru\",\"login\":\"\",\"name\":\"ivan durak\",\"birthday\":\"2000-02-24\"}",
+                new String[]{"400", "@Valid"});
+        putJsons.put("{\"email\":\"ivan@ya.ru\",\"login\":\"iva ndur\",\"name\":\"ivan durak\",\"birthday\":\"2000-02-24\"}",
+                new String[]{"400", "UserLoginValidator"});
+        // Birthday from future
+        putJsons.put("{\"email\":\"ivan@ya.ru\",\"login\":\"ivandur\",\"name\":\"ivan durak\",\"birthday\":\"2040-02-24\"}",
+                new String[]{"400", "UserBirthdayValidator"});
+        // Empty name + without name
+        putJsons.put("{\"email\":\"ivan@ya.ru\",\"login\":\"ivandur\",\"name\":\"\",\"birthday\":\"2000-02-24\"}",
+                new String[]{"404", "not found"});
+        putJsons.put("{\"email\":\"sofi@ya.ru\",\"login\":\"sofochka\",\"birthday\":\"2001-04-14\"}",
+                new String[]{"404", "not found"});
+        // Normal json (with wrong id + without id)
+        putJsons.put("{\"email\":\"oleg@ya.ru\",\"login\":\"olezhe\",\"name\":\"olen oleg\",\"birthday\":\"2003-06-21\"}",
+                new String[]{"404", "not found"});
+        putJsons.put("{\"id\":1045,\"email\":\"otto@ya.ru\",\"login\":\"bismark\",\"name\":\"otto bismark\",\"birthday\":\"1815-04-01\"}",
+                new String[]{"404", "not found"});
+        // Normal json with id
+        putJsons.put("{\"id\":1,\"email\":\"bobo@ya.ru\",\"login\":\"djbobo\",\"name\":\"dj bobo\",\"birthday\":\"1968-01-05\"}",
+                new String[]{"200", "djbobo"});
+
+        for (Map.Entry<String, String[]> entry : putJsons.entrySet()) {
+            request = new HttpEntity<>(entry.getKey(), headers);
+            response = restTemplate.exchange("/users", HttpMethod.PUT, request, String.class);
+            assertEquals(entry.getValue()[0], String.valueOf(response.getStatusCode().value()));
+            body = response.getBody();
+            assertNotNull(body);
+            assertTrue(body.contains(entry.getValue()[1]));
+        }
+
+        // ###### GET ALL ######
+
+        request = new HttpEntity<>("", headers);
+        response = restTemplate.exchange("/users", HttpMethod.GET, request, String.class);
+        assertEquals(200, response.getStatusCode().value());
+        body = response.getBody();
+        assertNotNull(body);
+        assertTrue(body.contains("djbobo"));
+        assertTrue(body.contains("bismark"));
+        assertTrue(body.contains("sofochka"));
+        assertTrue(body.contains("olezhe"));
+        assertFalse(body.contains("ivandur"));
+
+        // ###### GET BY ID ######
+
+        Map<String, String[]> getUrls = new HashMap<>();
+        // Bad id
+        getUrls.put("/users/f", new String[]{"400", "Bad Request"});
+        // Non-existing id
+        getUrls.put("/users/-1", new String[]{"404", "not found"});
+        getUrls.put("/users/0", new String[]{"404", "not found"});
+        getUrls.put("/users/10", new String[]{"404", "not found"});
+        // Existing id
+        getUrls.put("/users/1", new String[]{"200", "djbobo"});
+        getUrls.put("/users/2", new String[]{"200", "sofochka"});
+        getUrls.put("/users/3", new String[]{"200", "olezhe"});
+        getUrls.put("/users/4", new String[]{"200", "bismark"});
+
+        request = new HttpEntity<>("", headers);
+        for (Map.Entry<String, String[]> entry : getUrls.entrySet()) {
+            response = restTemplate.exchange(entry.getKey(), HttpMethod.GET, request, String.class);
+            assertEquals(entry.getValue()[0], String.valueOf(response.getStatusCode().value()));
+            body = response.getBody();
+            assertNotNull(body);
+            assertTrue(body.contains(entry.getValue()[1]));
+        }
+    }
+
+
+    /**
+     * Endpoint: /films
+     */
+    @Test
+    void filmsEndpoint() {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        HttpEntity<String> request;
+        ResponseEntity<String> response;
+        String body;
+
+        // ###### POST ######
+
+        Map<String, String[]> postJsons = new HashMap<>();
+        // Bad jsons
+        postJsons.put("", new String[]{"400", "Bad Request"});
+        postJsons.put("hrtfhyrth", new String[]{"400", "Bad Request"});
+        postJsons.put("{}", new String[]{"400", "@Valid"});
+        postJsons.put("{\"king\":\"sauron\"}", new String[]{"400", "@Valid"});
+        // Empty name + blank name
+        postJsons.put("{\"description\":\"has oscar\",\"releaseDate\":\"2024-05-21\",\"duration\":\"PT2H19M\"}",
+                new String[]{"400", "@Valid"});
+        postJsons.put("{\"name\":\" \",\"description\":\"has oscar\",\"releaseDate\":\"2024-05-21\",\"duration\":\"PT2H19M\"}",
+                new String[]{"400", "@Valid"});
+        // Early release date
+        postJsons.put("{\"name\":\"Anora\",\"description\":\"has oscar\",\"releaseDate\":\"1895-05-21\",\"duration\":\"PT2H19M\"}",
+                new String[]{"400", "FilmReleaseDateValidator"});
+        // Too big description
+        postJsons.put("{\"name\":\"Anora\",\"description\":\"The quick brown fox jumps over the lazy dog near the riverbank. " +
+                        "Sunny hills bloom with vivid colors, while birds sing sweetly. " +
+                        "Time flies fast as the wind carries dreams across the vast, open and blue sky.\"," +
+                        "\"releaseDate\":\"2024-05-21\",\"duration\":\"PT2H19M\"}",
+                new String[]{"400", "FilmDescriptionValidator"});
+        // Zero and negative duration
+        postJsons.put("{\"name\":\"Anora\",\"description\":\"has oscar\",\"releaseDate\":\"2024-05-21\",\"duration\":0}",
+                new String[]{"400", "FilmDurationValidator"});
+        postJsons.put("{\"name\":\"Anora\",\"description\":\"has oscar\",\"releaseDate\":\"2024-05-21\",\"duration\":-10}",
+                new String[]{"400", "FilmDurationValidator"});
+        // Normal json (with id + without id)
+        postJsons.put("{\"name\":\"Anora\",\"description\":\"has oscar\",\"releaseDate\":\"2024-05-21\",\"duration\":\"PT2H19M\"}",
+                new String[]{"200", "Anora"});
+        postJsons.put("{\"id\":1,\"name\":\"Terminator\",\"description\":\"no fate\",\"releaseDate\":\"1984-10-26\",\"duration\":\"PT1H48M\"}",
+                new String[]{"200", "Terminator"});
+
+        for (Map.Entry<String, String[]> entry : postJsons.entrySet()) {
+            request = new HttpEntity<>(entry.getKey(), headers);
+            response = restTemplate.exchange("/films", HttpMethod.POST, request, String.class);
+            assertEquals(entry.getValue()[0], String.valueOf(response.getStatusCode().value()));
+            body = response.getBody();
+            assertNotNull(body);
+            assertTrue(body.contains(entry.getValue()[1]));
+        }
+
+        // ###### PUT ######
+
+        Map<String, String[]> putJsons = new HashMap<>();
+        // Bad jsons
+        putJsons.put("", new String[]{"400", "Bad Request"});
+        putJsons.put("hrtfhyrth", new String[]{"400", "Bad Request"});
+        putJsons.put("{}", new String[]{"400", "@Valid"});
+        putJsons.put("{\"king\":\"sauron\"}", new String[]{"400", "@Valid"});
+        // Empty name + blank name
+        putJsons.put("{\"id\":1,\"description\":\"has oscar\",\"releaseDate\":\"2024-05-21\",\"duration\":\"PT2H19M\"}",
+                new String[]{"400", "@Valid"});
+        putJsons.put("{\"id\":1,\"name\":\" \",\"description\":\"has oscar\",\"releaseDate\":\"2024-05-21\",\"duration\":\"PT2H19M\"}",
+                new String[]{"400", "@Valid"});
+        // Early release date
+        putJsons.put("{\"id\":1,\"name\":\"Anora\",\"description\":\"has oscar\",\"releaseDate\":\"1895-05-21\",\"duration\":\"PT2H19M\"}",
+                new String[]{"400", "FilmReleaseDateValidator"});
+        // Too big description
+        putJsons.put("{\"id\":1,\"name\":\"Anora\",\"description\":\"The quick brown fox jumps over the lazy dog near the riverbank. " +
+                        "Sunny hills bloom with vivid colors, while birds sing sweetly. " +
+                        "Time flies fast as the wind carries dreams across the vast, open and blue sky.\"," +
+                        "\"releaseDate\":\"2024-05-21\",\"duration\":\"PT2H19M\"}",
+                new String[]{"400", "FilmDescriptionValidator"});
+        // Zero and negative duration
+        putJsons.put("{\"id\":1,\"name\":\"Anora\",\"description\":\"has oscar\",\"releaseDate\":\"2024-05-21\",\"duration\":0}",
+                new String[]{"400", "FilmDurationValidator"});
+        putJsons.put("{\"id\":1,\"name\":\"Anora\",\"description\":\"has oscar\",\"releaseDate\":\"2024-05-21\",\"duration\":-10}",
+                new String[]{"400", "FilmDurationValidator"});
+        // Normal json (with wrong id + without id)
+        putJsons.put("{\"id\":9,\"name\":\"Terminator\",\"description\":\"no fate\",\"releaseDate\":\"1984-10-26\",\"duration\":\"PT1H48M\"}",
+                new String[]{"404", "not found"});
+        putJsons.put("{\"name\":\"Anora\",\"description\":\"has oscar\",\"releaseDate\":\"2024-05-21\",\"duration\":\"PT2H19M\"}",
+                new String[]{"404", "not found"});
+        // Normal json with id
+        putJsons.put("{\"id\":1,\"name\":\"Inception\",\"description\":\"leonardo\",\"releaseDate\":\"2010-07-08\",\"duration\":\"PT2H28M\"}",
+                new String[]{"200", "Inception"});
+
+        for (Map.Entry<String, String[]> entry : putJsons.entrySet()) {
+            request = new HttpEntity<>(entry.getKey(), headers);
+            response = restTemplate.exchange("/films", HttpMethod.PUT, request, String.class);
+            assertEquals(entry.getValue()[0], String.valueOf(response.getStatusCode().value()));
+            body = response.getBody();
+            assertNotNull(body);
+            assertTrue(body.contains(entry.getValue()[1]));
+        }
+
+        // ###### GET ALL ######
+
+        request = new HttpEntity<>("", headers);
+        response = restTemplate.exchange("/films", HttpMethod.GET, request, String.class);
+        assertEquals(200, response.getStatusCode().value());
+        body = response.getBody();
+        assertNotNull(body);
+        assertTrue(body.contains("Terminator"));
+        assertTrue(body.contains("Inception"));
+        assertFalse(body.contains("Anora"));
+
+        // ###### GET BY ID ######
+
+        Map<String, String[]> getUrls = new HashMap<>();
+        // Bad id
+        getUrls.put("/films/f", new String[]{"400", "Bad Request"});
+        // Non-existing id
+        getUrls.put("/films/-1", new String[]{"404", "not found"});
+        getUrls.put("/films/0", new String[]{"404", "not found"});
+        getUrls.put("/films/10", new String[]{"404", "not found"});
+        // Existing id
+        getUrls.put("/films/1", new String[]{"200", "Inception"});
+        getUrls.put("/films/2", new String[]{"200", "Terminator"});
+
+        request = new HttpEntity<>("", headers);
+        for (Map.Entry<String, String[]> entry : getUrls.entrySet()) {
+            response = restTemplate.exchange(entry.getKey(), HttpMethod.GET, request, String.class);
+            assertEquals(entry.getValue()[0], String.valueOf(response.getStatusCode().value()));
+            body = response.getBody();
+            assertNotNull(body);
+            assertTrue(body.contains(entry.getValue()[1]));
+        }
+    }
+
 
 }

--- a/src/test/java/ru/yandex/practicum/filmorate/model/validators/FilmValidatorTest.java
+++ b/src/test/java/ru/yandex/practicum/filmorate/model/validators/FilmValidatorTest.java
@@ -1,0 +1,112 @@
+package ru.yandex.practicum.filmorate.model.validators;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import ru.yandex.practicum.filmorate.model.Film;
+import ru.yandex.practicum.filmorate.model.exceptions.ValidationException;
+import ru.yandex.practicum.filmorate.model.validators.film.*;
+
+import java.time.Duration;
+import java.time.LocalDate;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class FilmValidatorTest {
+
+    private Film film;
+
+    private final FilmValidator filmValidator = FilmValidatorBuilder.builder()
+            .register(new FilmNameValidator())
+            .register(new FilmDescriptionValidator())
+            .register(new FilmReleaseDateValidator())
+            .register(new FilmDurationValidator())
+            .build();
+
+    @BeforeEach
+    void init() {
+        film = new Film();
+        film.setId(3);
+        film.setName("Inception");
+        film.setDescription("A thief enters dreams to steal secrets, facing blurred lines between reality and illusion.");
+        film.setReleaseDate(LocalDate.of(2010, 7, 8));
+        film.setDuration(Duration.parse("PT2H28M"));
+    }
+
+    @Test
+    void passesAllValidators() {
+        assertDoesNotThrow(() -> {
+            filmValidator.validate(film);
+        });
+    }
+
+    @Test
+    void nameValidator() {
+        film.setName("");
+        assertThrows(ValidationException.class, () -> {
+            filmValidator.validate(film);
+        });
+
+        film.setName(null);
+        assertThrows(ValidationException.class, () -> {
+            filmValidator.validate(film);
+        });
+    }
+
+    @Test
+    void descriptionValidator() {
+        film.setDescription("A skilled thief enters dreams to steal some secrets. " +
+                "Hired for an impossible job, he dives into layers of reality and illusion, battling to discern " +
+                "truth as his mind bends under the weight of deception.");
+        assertThrows(ValidationException.class, () -> {
+            filmValidator.validate(film);
+        });
+
+        film.setDescription("");
+        assertDoesNotThrow(() -> {
+            filmValidator.validate(film);
+        });
+
+        film.setDescription(null);
+        assertDoesNotThrow(() -> {
+            filmValidator.validate(film);
+        });
+    }
+
+    @Test
+    void releaseDateValidator() {
+        film.setReleaseDate(LocalDate.of(1890, 7, 8));
+        assertThrows(ValidationException.class, () -> {
+            filmValidator.validate(film);
+        });
+
+        film.setReleaseDate(LocalDate.of(1895, 12, 28));
+        assertDoesNotThrow(() -> {
+            filmValidator.validate(film);
+        });
+
+        film.setReleaseDate(null);
+        assertDoesNotThrow(() -> {
+            filmValidator.validate(film);
+        });
+    }
+
+    @Test
+    void durationValidator() {
+        film.setDuration(Duration.ZERO);
+        assertThrows(ValidationException.class, () -> {
+            filmValidator.validate(film);
+        });
+
+        film.setDuration(Duration.ofHours(-1L));
+        assertThrows(ValidationException.class, () -> {
+            filmValidator.validate(film);
+        });
+
+        film.setDuration(null);
+        assertDoesNotThrow(() -> {
+            filmValidator.validate(film);
+        });
+    }
+
+}

--- a/src/test/java/ru/yandex/practicum/filmorate/model/validators/UserValidatorTest.java
+++ b/src/test/java/ru/yandex/practicum/filmorate/model/validators/UserValidatorTest.java
@@ -1,0 +1,121 @@
+package ru.yandex.practicum.filmorate.model.validators;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import ru.yandex.practicum.filmorate.model.User;
+import ru.yandex.practicum.filmorate.model.exceptions.ValidationException;
+import ru.yandex.practicum.filmorate.model.validators.user.*;
+
+import java.time.LocalDate;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class UserValidatorTest {
+
+    private User user;
+
+    private final UserValidator userValidator = UserValidatorBuilder.builder()
+            .register(new UserEmailValidator())
+            .register(new UserLoginValidator())
+            .register(new UserNameValidator())
+            .register(new UserBirthdayValidator())
+            .build();
+
+    @BeforeEach
+    void init() {
+        user = new User();
+        user.setId(3);
+        user.setEmail("ivan@ya.ru");
+        user.setLogin("ivandur");
+        user.setName("Ivan Durak");
+        user.setBirthday(LocalDate.of(1991, 4, 1));
+    }
+
+    @Test
+    void passesAllValidators() {
+        assertDoesNotThrow(() -> {
+            userValidator.validate(user);
+        });
+    }
+
+    @Test
+    void emailValidator() {
+        user.setEmail("ivanya.ru");
+        assertThrows(ValidationException.class, () -> {
+            userValidator.validate(user);
+        });
+
+        user.setEmail("@ya.ru");
+        assertThrows(ValidationException.class, () -> {
+            userValidator.validate(user);
+        });
+
+        user.setEmail("");
+        assertThrows(ValidationException.class, () -> {
+            userValidator.validate(user);
+        });
+
+        user.setEmail(null);
+        assertThrows(ValidationException.class, () -> {
+            userValidator.validate(user);
+        });
+    }
+
+    @Test
+    void loginValidator() {
+        user.setLogin("ivan durak");
+        assertThrows(ValidationException.class, () -> {
+            userValidator.validate(user);
+        });
+
+        user.setLogin("");
+        assertThrows(ValidationException.class, () -> {
+            userValidator.validate(user);
+        });
+
+        user.setLogin(null);
+        assertThrows(ValidationException.class, () -> {
+            userValidator.validate(user);
+        });
+    }
+
+    @Test
+    void birthdayValidator() {
+        user.setBirthday(LocalDate.now().plusDays(10));
+        assertThrows(ValidationException.class, () -> {
+            userValidator.validate(user);
+        });
+
+        user.setBirthday(LocalDate.now());
+        assertDoesNotThrow(() -> {
+            userValidator.validate(user);
+        });
+
+        user.setBirthday(null);
+        assertDoesNotThrow(() -> {
+            userValidator.validate(user);
+        });
+    }
+
+    @Test
+    void nameValidator() {
+        assertDoesNotThrow(() -> {
+            userValidator.validate(user);
+        });
+        assertEquals("Ivan Durak", user.getName());
+
+        user.setName("");
+        assertDoesNotThrow(() -> {
+            userValidator.validate(user);
+        });
+        assertEquals("ivandur", user.getName());
+
+        user.setName(null);
+        assertDoesNotThrow(() -> {
+            userValidator.validate(user);
+        });
+        assertEquals("ivandur", user.getName());
+    }
+
+
+}


### PR DESCRIPTION
+ обновлена версия Spring до 3.4.3
+ добавлена зависимость spring-boot-starter-validation для аннотаций @ Valid
+ lombok добавлен как Annotation Processor в maven-compiler-plugin чтобы maven обрабатывал его аннотации
+ добавлены классы данных Film, User, аннотированы как @ Data, некоторые поля аннотированы для валидации
+ добавлено исключение ValidationException для обработки валидации
+ добавлены валидаторы для классов Film, User . Использованы паттерны Chain of responsibility + Builder:
На примере User: 

> Для каждой валидации используется отдельный класс-валидатор, имплементирующий интерфейс UserValidator. Методы интерфейса validate и setNext реализованы в абстрактном классе UserAbstractValidator, от которого наследуются все классы-валидаторы. Класс-валидатор переопределяет метод абстрактного класса performValidation, прописывая там логику валидации с бросанием исключений. 
> В цепочку валидаторы объединяюся с помощью паттерна Builder, реализованного в отдельном классе UserValidatorBuilder

+ добавлены тесты для всех валидаторов
+ добавлено исключение NotFoundException для обработки не найденных Fim, User при запросах GET, PUT
+ добавлены контроллеры эндпойнтов GET /users, POST /users, PUT /users, GET /users/{id}
+ добавлены контроллеры эндпойнтов GET /films, POST /films, PUT /films, GET /films/{id}
+ добавлен глобальный обработчик исключений GlobalExceptionHandler (RestControllerAdvice) для обработки исключений валидации, встроенной валидации Spring, NotFoundException
+ добавлено логирование INFO всех успешных операций записи
+ добавлено логирование DEBUG для всех валидаторов и WARN для обработчиков исключений
+ добавлены интеграционные тесты всех эндпойнтов API с помощью @ SpringBootTest и TestRestTemplate